### PR TITLE
Fix Xcode 9.1 characters deprecation warning and off-by-one error

### DIFF
--- a/TinyLog/Classes/TinyLog.swift
+++ b/TinyLog/Classes/TinyLog.swift
@@ -32,7 +32,7 @@ fileprivate func fileName(_ filePath: String) -> String {
 
 fileprivate func functionNameByStrippingParameters(_ function: String) -> String {
     if let startIndex = function.index(of: "(") {
-        return String(function[...startIndex])
+        return String(function[..<startIndex])
     } else {
         return function
     }

--- a/TinyLog/Classes/TinyLog.swift
+++ b/TinyLog/Classes/TinyLog.swift
@@ -31,7 +31,7 @@ fileprivate func fileName(_ filePath: String) -> String {
 }
 
 fileprivate func functionNameByStrippingParameters(_ function: String) -> String {
-    if let startIndex = function.characters.index(of: "(") {
+    if let startIndex = function.index(of: "(") {
         return String(function[...startIndex])
     } else {
         return function


### PR DESCRIPTION
This fixes the following warning in Xcode 9.1 and later:

    'characters' is deprecated: Please use String or Substring directly

I also fixed an off-by-one error in `functionNameByStrippingParameters` that was introduced in the Swift 3 to 4 conversion, because it used the `...index` instead of `..<index` which matches up to the index.

Due to the off-by-one error function names where printed as `ViewController.viewDidLoad(:23 - Foo` instead of `ViewController.viewDidLoad:23 - Foo`.